### PR TITLE
Document kailleraclient.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ Thumbs.db
 /Source/Project64-input/Version.h
 /Source/Project64-video/Version.h
 /Source/RSP/Version.h
+/Source/Project64/kailleraclient.dll

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,6 +20,10 @@ This can be done in the visual studio welcome screen. The git URL is:
 https://github.com/smash64-dev/project64.git
 ```
 
+## Kaillera steps
+
+Download [Project64KSE](https://smash64.online/). Copy and rename the `Net/plugin.dll` file in KSE into `Source/Project64/kailleraclient.dll` of this project.
+
 ## Build from source
 
 Open the `Project64.sln` file in Visual Studio. You can now build the solution from the Build menu.

--- a/Source/Project64/Kaillera/CKaillera.cpp
+++ b/Source/Project64/Kaillera/CKaillera.cpp
@@ -384,7 +384,7 @@ int CKaillera::LoadKailleraFuncs()
 	}
 	else
 	{
-		MessageBox(NULL, L"Kaillearclient.dll not found. Please place it in the main folder and run Project64k again!", L"OOPS", NULL);
+		MessageBox(NULL, L"kailleraclient.dll not found. Please place it in the main folder and run Project64k again!", L"OOPS", NULL);
 		PostQuitMessage(0);
 	}
 


### PR DESCRIPTION
This documents getting the kailleraclient.dll file into the project. Also fixing a typo in the error message when kailleraclient.dll doesn't exist. I didn't think kailleraclient.dll should be in source control, so I gitignored it.

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes